### PR TITLE
Switch files to c++ and make splash screen printing iterative

### DIFF
--- a/src/drivers/ports.cpp
+++ b/src/drivers/ports.cpp
@@ -1,6 +1,6 @@
 /**
- * File: ports.c
- * Author: Keeton Feavel
+ * File: ports.cpp
+ * Author: Keeton Feavel and James Osborne
  */
 
 /**********************************************************

--- a/src/drivers/screen.cpp
+++ b/src/drivers/screen.cpp
@@ -1,6 +1,6 @@
 /**
- * File: screen.c
- * Author: Keeton Feavel
+ * File: screen.cpp
+ * Author: Keeton Feavel and James Osborne
  */
 
 #include "screen.h"
@@ -85,15 +85,16 @@ int print_char(char c, int col, int row, char attr) {
 
     /* Check if the offset is over screen size and scroll */
     if (offset >= MAX_ROWS * MAX_COLS * 2) {
-        int i;
-        for (i = 1; i < MAX_ROWS; i++) 
-            memory_copy(get_offset(0, i) + VIDEO_ADDRESS,
-                        get_offset(0, i-1) + VIDEO_ADDRESS,
+        for (int i = 1; i < MAX_ROWS; i++) 
+            memory_copy(((char*) get_offset(0, i)) + VIDEO_ADDRESS,
+                        ((char*) get_offset(0, i-1)) + VIDEO_ADDRESS,
                         MAX_COLS * 2);
 
         /* Blank last line */
-        char * last_line = get_offset(0, MAX_ROWS - 1) + VIDEO_ADDRESS;
-        for (i = 0; i < MAX_COLS * 2; i++) last_line[i] = 0;
+        char* last_line = ((char*) get_offset(0, MAX_ROWS - 1)) + VIDEO_ADDRESS;
+        for (int i = 0; i < MAX_COLS * 2; i++) {
+            last_line[i] = 0;
+        }
 
         offset -= 2 * MAX_COLS;
     }
@@ -111,6 +112,7 @@ int get_cursor_offset() {
     int offset = port_byte_in(REG_SCREEN_DATA) << 8; 	/* High byte: << 8 */
     port_byte_out(REG_SCREEN_CTRL, 15);
     offset += port_byte_in(REG_SCREEN_DATA);
+
     return offset * 2; 									/* Position * size of character cell */
 }
 

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -1,6 +1,6 @@
 /**
- * File: kernel.c
- * Author: Keeton Feavel
+ * File: kernel.cpp
+ * Author: Keeton Feavel and James Osborne
  * 
  * Panix kernel main source file.
  * Includes the kernel's main() function
@@ -32,12 +32,17 @@ void entryTest() {
  */
 int main() {
     clear_screen();
-    kprint("     ____  ___    _   _______  __ \n");
-    kprint("    / __ \\/   |  / | / /  _/ |/ /\n");
-    kprint("   / /_/ / /| | /  |/ // / |   /  \n");
-    kprint("  / ____/ ___ |/ /|  // / /   |   \n");
-    kprint(" /_/   /_/  |_/_/ |_/___//_/|_|   \n");
-    kprint("\nWelcome to the PANIX kernel!\n");
+    char splashScreen [6][36] = {
+        "     ____  ___    _   _______  __ \n",
+        "    / __ \\/   |  / | / /  _/ |/ /\n",
+        "   / /_/ / /| | /  |/ // / |   /  \n",
+        "  / ____/ ___ |/ /|  // / /   |   \n",
+        " /_/   /_/  |_/_/ |_/___//_/|_|   \n",
+        "\nWelcome to the PANIX kernel!\n"
+    };
+    for (int i = 0; i < 6; i++) {
+        kprint(splashScreen[i]);
+    }
    /* Fill up the screen */
 
     while (1) {

--- a/src/kernel/util/util.cpp
+++ b/src/kernel/util/util.cpp
@@ -1,6 +1,6 @@
 /**
- * File: util.c
- * Author: Keeton Feavel
+ * File: util.cpp
+ * Author: Keeton Feavel and James Osborne
  */
 
 void memory_copy(char *source, char *dest, int nbytes) {


### PR DESCRIPTION
This requires a configuration to the cross-compiled version of gcc. The configure command instead becomes:
`../gcc-8.2.0/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --disable-libssp --enable-languages=c,c++ --without-headers`

Otherwise the process is the same.