### PR TITLE
Fixed the order of month and day in RTC::printTimeAndDate()

### DIFF
--- a/src/drivers/rtc/RTC.cpp
+++ b/src/drivers/rtc/RTC.cpp
@@ -87,9 +87,9 @@ void RTC::printTimeAndDate() {
     intToString(day, dayStr);
     intToString(month, monthStr);
     kprint("\nToday's Date: ");
-    kprint(dayStr);
-    kprint("/");
     kprint(monthStr);
+    kprint("/");
+    kprint(dayStr);
     kprint(" - UTC: ");
     kprint(hourStr);
     kprint(":");


### PR DESCRIPTION
The ordering was DD/MM and I changed it to MM/DD